### PR TITLE
Document migrations not executed if no datasource injected

### DIFF
--- a/src/main/docs/guide/configuration.adoc
+++ b/src/main/docs/guide/configuration.adoc
@@ -20,6 +20,12 @@ In that directory you need to include all your migrations, for example:
 include::{flywaytests}/resources/databasemigrations/V1__create-books-schema.sql[indent=0]
 ----
 
+Flyway migrations are executed when datasources are created. Because micronaut beans are, by default, created
+lazily, if you do not inject a `Datasource` somewhere, then migrations are not executed.
+This may be the case when you create a command in a separate module just to run migrations, e.g. using micronaut support
+for https://docs.micronaut.io/latest/guide/index.html#commandLineApps[picocli].
+In this case it is enough to inject a `Datasource` in anyone of your singletons and migrations will be executed.
+
 There are several options available for configuration:
 
 include::{includedir}configurationProperties/io.micronaut.configuration.dbmigration.flyway.FlywayConfigurationProperties.adoc[]


### PR DESCRIPTION
I have a separate gradle module where I only have a picocli standalone cli application I use to run migrations and dump some info.

It took me a while to figure it out why migrations where not executed until I noticed that the hook to execute migrations is the `onCreate` of `Datasource` beans. Given that micronaut creates beans lazily, migrations were not executed because no `Datasource` were created.

Just injecting it in any singleton will cause migrations to be executed. Not proposing a change to this approach as in 99% of use cases this works perfectly.

Just proposing to add a sentence to the docs to make this clear.