### PR TITLE
test: use default classpath:db/migration

### DIFF
--- a/flyway/src/test/groovy/io/micronaut/flyway/FlywayAsyncSpec.groovy
+++ b/flyway/src/test/groovy/io/micronaut/flyway/FlywayAsyncSpec.groovy
@@ -24,7 +24,6 @@ class FlywayAsyncSpec extends Specification {
         'jpa.default.properties.hibernate.hbm2ddl.auto': 'none',
         'jpa.default.properties.hibernate.show_sql'    : true,
 
-        'flyway.datasources.default.locations'         : 'classpath:databasemigrations',
         'flyway.datasources.default.async'             : true,
     ]
 


### PR DESCRIPTION
Test `FlywayAsyncSpec` is failing. I think it is because it was using a non existing location. 

I've changed it to use for 'flyway.datasources.default.locations'  the default value `classpath:db/migration`  instead
`classpath:databasemigrations`

