### PR TITLE
Upgrade to Flyway 7.4.0

### DIFF
--- a/flyway/src/main/java/io/micronaut/flyway/graalvm/MicronautPathLocationScanner.java
+++ b/flyway/src/main/java/io/micronaut/flyway/graalvm/MicronautPathLocationScanner.java
@@ -18,7 +18,7 @@ package io.micronaut.flyway.graalvm;
 import io.micronaut.context.condition.Condition;
 import io.micronaut.core.annotation.Internal;
 import org.flywaydb.core.api.Location;
-import org.flywaydb.core.internal.resource.LoadableResource;
+import org.flywaydb.core.api.resource.LoadableResource;
 import org.flywaydb.core.internal.resource.classpath.ClassPathResource;
 import org.flywaydb.core.internal.scanner.classpath.ResourceAndClassScanner;
 import org.slf4j.LoggerFactory;

--- a/flyway/src/main/java/io/micronaut/flyway/graalvm/ScannerSubstitutions.java
+++ b/flyway/src/main/java/io/micronaut/flyway/graalvm/ScannerSubstitutions.java
@@ -20,7 +20,7 @@ import com.oracle.svm.core.annotate.Substitute;
 import com.oracle.svm.core.annotate.TargetClass;
 import io.micronaut.core.annotation.Internal;
 import org.flywaydb.core.api.Location;
-import org.flywaydb.core.internal.resource.LoadableResource;
+import org.flywaydb.core.api.resource.LoadableResource;
 import org.flywaydb.core.internal.scanner.LocationScannerCache;
 import org.flywaydb.core.internal.scanner.ResourceNameCache;
 import org.flywaydb.core.internal.scanner.classpath.ResourceAndClassScanner;

--- a/gradle.properties
+++ b/gradle.properties
@@ -6,7 +6,7 @@ micronautTestVersion=2.2.1
 groovyVersion=3.0.5
 spockVersion=2.0-M3-groovy-3.0
 
-flywayVersion=7.3.2
+flywayVersion=7.4.0
 gormHibernateVersion=7.0.3.RELEASE
 
 title=Micronaut Flyway


### PR DESCRIPTION
Upgrades to Flyway 7.4.0. The idea is to release a new minor version after this is merged and include the version in Micronaut 2.3.0.

Release notes: https://flywaydb.org/documentation/learnmore/releaseNotes#7.4.0

There is a [breaking change](https://github.com/flyway/flyway/issues/3013) (a class moved to another package) but I think this shouldn't affect our users because:
- The class in Flyway was in an `internal` package and now it is on a public `api` package. So if users were using the internal class, it's on it's own risk.
- In our code, the two classes I've modified are GraalVM related and they are `@Internal`.

I've tried this locally and everything works with GraalVM.

@jameskleeh what do you think?