### PR TITLE
use RXJava instead of reactor again.

### DIFF
--- a/flyway/build.gradle
+++ b/flyway/build.gradle
@@ -11,7 +11,6 @@ dependencies {
     api "io.micronaut:micronaut-management"
     api "io.micronaut.sql:micronaut-jdbc"
 
-    implementation "io.projectreactor:reactor-core"
     implementation 'jakarta.inject:jakarta.inject-api:2.0.0'
 
     testAnnotationProcessor "io.micronaut:micronaut-inject-java"

--- a/flyway/src/main/java/io/micronaut/flyway/endpoint/FlywayEndpoint.java
+++ b/flyway/src/main/java/io/micronaut/flyway/endpoint/FlywayEndpoint.java
@@ -20,9 +20,10 @@ import io.micronaut.context.ApplicationContext;
 import io.micronaut.inject.qualifiers.Qualifiers;
 import io.micronaut.management.endpoint.annotation.Endpoint;
 import io.micronaut.management.endpoint.annotation.Read;
+import io.reactivex.Flowable;
+
 import org.flywaydb.core.Flyway;
 import org.reactivestreams.Publisher;
-import reactor.core.publisher.Flux;
 
 import java.util.Arrays;
 import java.util.Collection;
@@ -60,7 +61,7 @@ public class FlywayEndpoint {
     @Read
     public Publisher<FlywayReport> flywayMigrations() {
 
-        return Flux.fromIterable(flywayConfigurationProperties)
+        return Flowable.fromIterable(flywayConfigurationProperties)
                 .filter(FlywayConfigurationProperties::isEnabled)
                 .map(c -> new Pair<>(c,
                         applicationContext


### PR DESCRIPTION
in 62b6c8c25b5a4ca5bd89aecf1f84ec93a2ce6233  the publisher for the FlywayEndpoint was changed from Flowable to Flux.
It's excessive to require the whole reactor library for a single line of code.