### PR TITLE
Describe JDBC dependencies

### DIFF
--- a/src/main/docs/guide/introduction.adoc
+++ b/src/main/docs/guide/introduction.adoc
@@ -2,3 +2,5 @@ To use the Micronaut's integration with https://flywaydb.org/[Flyway] you must h
 dependency on your classpath:
 
 dependency:micronaut-flyway[groupId="io.micronaut.flyway"]
+
+You also need dependencies for the JDBC connection pool and the JDBC driver as described in https://micronaut-projects.github.io/micronaut-sql/latest/guide/#jdbc[Configuring a JDBC DataSource].


### PR DESCRIPTION
I tried to add `micronaut-flyway` retroactively to a project I created without it, and it took me a while to get it working. If these dependencies are missing, nothing happens and Flyway does not run.