### PR TITLE
Upgrade to Flyway 7.15.0

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -6,7 +6,7 @@ micronautTestVersion=2.3.6
 groovyVersion=3.0.8
 spockVersion=2.0-groovy-3.0
 
-flywayVersion=7.12.1
+flywayVersion=7.15.0
 gormHibernateVersion=7.0.3.RELEASE
 
 title=Micronaut Flyway

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,4 +1,4 @@
-projectVersion=4.1.1-SNAPSHOT
+projectVersion=4.2.0-SNAPSHOT
 micronautDocsVersion=2.0.0.RC1
 micronautVersion=2.5.12
 micronautTestVersion=2.3.6
@@ -15,7 +15,7 @@ projectUrl=http://micronaut.io
 githubSlug=micronaut-projects/micronaut-flyway
 developers=Ivan Lopez
 
-githubCoreBranch=3.0.x
+githubCoreBranch=3.1.x
 bomProperty=micronautFlywayVersion
 bomProperties=flywayVersion
 


### PR DESCRIPTION
- Upgrade to Flyway 7.15.0
- New version is 4.2.0-SNAPSHOT and targets Micronaut 3.1.0
