### PR TITLE
Fix GraalVM warning

### DIFF
--- a/flyway/src/main/resources/META-INF/native-image/io.micronaut.flyway/flyway/native-image.properties
+++ b/flyway/src/main/resources/META-INF/native-image/io.micronaut.flyway/flyway/native-image.properties
@@ -1,2 +1,2 @@
 Args = -H:IncludeResources=org/flywaydb/core/internal/version.txt \
-       --initialize-at-run-time=org.flywaydb.core.internal.util.FeatureDetector
+       --initialize-at-run-time=org.flywaydb.core.internal.util.FeatureDetector,io.micronaut.flyway.$GormMigrationRunner$Definition


### PR DESCRIPTION
This PR fixes this GraalVM warning:

```
Warning: class initialization of class io.micronaut.flyway.$GormMigrationRunner$Definition failed with exception java.lang.NoClassDefFoundError: org/grails/orm/hibernate/HibernateDatastore. This class will be initialized at run time because option --allow-incomplete-classpath is used for image building. Use the option --initialize-at-run-time=io.micronaut.flyway.$GormMigrationRunner$Definition to explicitly request delayed initialization of this class.
```