### PR TITLE
Upgrade to build plugins 5.0.2

### DIFF
--- a/buildSrc/src/main/groovy/io.micronaut.build.internal.flyway-base.gradle
+++ b/buildSrc/src/main/groovy/io.micronaut.build.internal.flyway-base.gradle
@@ -1,2 +1,0 @@
-version = projectVersion
-group = 'io.micronaut.flyway'

--- a/buildSrc/src/main/groovy/io.micronaut.build.internal.flyway-module.gradle
+++ b/buildSrc/src/main/groovy/io.micronaut.build.internal.flyway-module.gradle
@@ -1,4 +1,3 @@
 plugins {
-    id 'io.micronaut.build.internal.flyway-base'
     id "io.micronaut.build.internal.module"
 }

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,4 +1,5 @@
 projectVersion=5.0.1-SNAPSHOT
+projectGroup=io.micronaut.flyway
 micronautDocsVersion=2.0.0
 micronautVersion=3.1.3
 micronautTestVersion=3.0.3

--- a/settings.gradle
+++ b/settings.gradle
@@ -6,7 +6,7 @@ pluginManagement {
 }
 
 plugins {
-    id 'io.micronaut.build.shared.settings' version '5.0.1'
+    id 'io.micronaut.build.shared.settings' version '5.0.2'
 }
 
 rootProject.name = 'flyway-parent'


### PR DESCRIPTION
This fixes snapshot publication and simplifies the build setup.