### PR TITLE
Move to using our latest build infrastructure

### DIFF
--- a/flyway-bom/build.gradle
+++ b/flyway-bom/build.gradle
@@ -1,11 +1,3 @@
 plugins {
     id "io.micronaut.build.internal.bom"
 }
-
-dependencies {
-    constraints {
-        api("org.flywaydb:flyway-core:$flywayVersion")
-        api("org.flywaydb:flyway-mysql:$flywayVersion")
-        api("org.flywaydb:flyway-sqlserver:$flywayVersion")
-    }
-}

--- a/flyway/build.gradle
+++ b/flyway/build.gradle
@@ -3,27 +3,25 @@ plugins {
 }
 
 dependencies {
-    annotationProcessor 'io.micronaut:micronaut-graal'
+    annotationProcessor libs.micronaut.graal
 
-    compileOnly 'io.micronaut:micronaut-inject-java'
-    compileOnly 'org.graalvm.nativeimage:svm'
-    compileOnly "org.grails:grails-datastore-gorm-hibernate5:$gormHibernateVersion"
+    compileOnly libs.graal
+    compileOnly libs.grails.datastore.gorm.hibernate5
 
-    api "org.flywaydb:flyway-core:$flywayVersion"
-    api 'io.micronaut:micronaut-management'
-    api 'io.micronaut.sql:micronaut-jdbc'
+    api libs.managed.flyway
+    api libs.micronaut.management
+    api libs.micronaut.jdbc
 
-    implementation 'io.projectreactor:reactor-core'
-    implementation 'jakarta.inject:jakarta.inject-api'
+    implementation libs.projectreactor
 
-    testAnnotationProcessor 'io.micronaut:micronaut-inject-java'
-    testImplementation "org.codehaus.groovy:groovy-sql:$groovyVersion"
-    testImplementation 'io.micronaut:micronaut-http-client'
-    testImplementation 'io.micronaut:micronaut-http-server-netty'
-    testImplementation 'io.micronaut.sql:micronaut-jdbc-hikari'
-    testImplementation 'io.micronaut.groovy:micronaut-hibernate-gorm'
-    testImplementation "org.spockframework:spock-core:$spockVersion"
-    testImplementation "org.grails:grails-datastore-gorm-hibernate5:$gormHibernateVersion"
-    testImplementation 'com.h2database:h2'
-    testAnnotationProcessor 'javax.persistence:javax.persistence-api:2.2'
+    testAnnotationProcessor libs.micronaut.inject.java
+    testAnnotationProcessor libs.persistence.api
+
+    testImplementation libs.groovy.sql
+    testImplementation libs.micronaut.http.client
+    testImplementation libs.micronaut.http.server.netty
+    testImplementation libs.micronaut.jdbc.hikari
+    testImplementation libs.micronaut.hibernate.gorm
+    testImplementation libs.grails.datastore.gorm.hibernate5
+    testImplementation libs.h2
 }

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,13 +1,11 @@
 projectVersion=5.2.1-SNAPSHOT
 projectGroup=io.micronaut.flyway
+
 micronautDocsVersion=2.0.0
 micronautVersion=3.3.4
 micronautTestVersion=3.0.5
 groovyVersion=3.0.10
 spockVersion=2.0-groovy-3.0
-
-flywayVersion=8.4.4
-gormHibernateVersion=7.2.1
 
 title=Micronaut Flyway
 projectDesc=Integration between Micronaut and Flyway

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,0 +1,29 @@
+[versions]
+managed-flyway = "8.4.4"
+
+gorm-hibernate = "7.2.1"
+persistence-api = '2.2'
+
+[libraries]
+managed-flyway = { module = "org.flywaydb:flyway-core", version.ref = "managed-flyway" }
+managed-flyway-mysql = { module = "org.flywaydb:flyway-mysql", version.ref = "managed-flyway" }
+managed-flyway-sqlserver = { module = "org.flywaydb:flyway-sqlserver", version.ref = "managed-flyway" }
+
+micronaut-graal = { module = "io.micronaut:micronaut-graal" }
+micronaut-hibernate-gorm = { module = "io.micronaut.groovy:micronaut-hibernate-gorm" }
+micronaut-http-client = { module = "io.micronaut:micronaut-http-client" }
+micronaut-http-server-netty = { module = "io.micronaut:micronaut-http-server-netty" }
+micronaut-inject-java = { module = 'io.micronaut:micronaut-inject-java' }
+micronaut-jdbc = { module = "io.micronaut.sql:micronaut-jdbc" }
+micronaut-jdbc-hikari = { module = "io.micronaut.sql:micronaut-jdbc-hikari" }
+micronaut-management = { module = "io.micronaut:micronaut-management" }
+
+graal = { module = "org.graalvm.nativeimage:svm" }
+grails-datastore-gorm-hibernate5 = { module = "org.grails:grails-datastore-gorm-hibernate5", version.ref = "gorm-hibernate" }
+
+groovy-sql = { module = "org.codehaus.groovy:groovy-sql" }
+
+h2 = { module = "com.h2database:h2" }
+
+persistence-api = { module = 'javax.persistence:javax.persistence-api', version.ref = 'persistence-api'}
+projectreactor = { module = 'io.projectreactor:reactor-core' }


### PR DESCRIPTION
This moves to using managed versions and a library catalog, this means that we get the
managed flyway version in our catalog toml file exported by the bom.

This is the only change, no other dependencies have changed, so I believe this can
go out as a patch release.

Fixes #304