### PR TITLE
Update flyway to use Serde and latest Milestones and RCs for 4.0.0

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -2,12 +2,3 @@ plugins {
     id 'io.micronaut.build.internal.docs'
     id 'io.micronaut.build.internal.quality-reporting'
 }
-
-repositories {
-    mavenCentral()
-}
-configurations.all {
-    resolutionStrategy {
-        preferProjectModules()
-    }
-}

--- a/buildSrc/src/main/groovy/io.micronaut.build.internal.flyway-base.gradle
+++ b/buildSrc/src/main/groovy/io.micronaut.build.internal.flyway-base.gradle
@@ -1,3 +1,9 @@
 repositories {
     mavenCentral()
 }
+
+configurations.all {
+    resolutionStrategy {
+        preferProjectModules()
+    }
+}

--- a/flyway/build.gradle
+++ b/flyway/build.gradle
@@ -4,8 +4,10 @@ plugins {
 
 dependencies {
     annotationProcessor mn.micronaut.graal
+    annotationProcessor mnSerde.micronaut.serde.processor
 
     compileOnly libs.graal.svm
+    compileOnly mnSerde.micronaut.serde.api
 
     api libs.managed.flyway
     api mn.micronaut.management

--- a/flyway/src/main/java/io/micronaut/flyway/endpoint/FlywayReport.java
+++ b/flyway/src/main/java/io/micronaut/flyway/endpoint/FlywayReport.java
@@ -16,9 +16,8 @@
 package io.micronaut.flyway.endpoint;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
-import com.fasterxml.jackson.databind.annotation.JsonSerialize;
 import io.micronaut.core.annotation.Creator;
-import io.micronaut.core.annotation.Introspected;
+import io.micronaut.serde.annotation.Serdeable;
 import org.flywaydb.core.api.MigrationInfo;
 
 import java.util.List;
@@ -29,7 +28,7 @@ import java.util.List;
  * @author Iván López
  * @since 1.0.0
  */
-@Introspected
+@Serdeable
 public class FlywayReport {
 
     private final String name;
@@ -56,7 +55,6 @@ public class FlywayReport {
     /**
      * @return The list of change migrations
      */
-    @JsonSerialize(contentAs = MigrationInfo.class)
     public List<MigrationInfo> getMigrations() {
         return migrations;
     }

--- a/flyway/src/test/groovy/io/micronaut/flyway/EventListenerSpec.groovy
+++ b/flyway/src/test/groovy/io/micronaut/flyway/EventListenerSpec.groovy
@@ -24,7 +24,9 @@ class EventListenerSpec extends AbstractFlywaySpec {
             'jpa.default.properties.hibernate.show_sql'    : true,
 
             'flyway.datasources.default.locations'         : 'classpath:moremigrations',
-            'flyway.datasources.default.clean-schema'      : true)
+            'flyway.datasources.default.clean-disabled'    : false,
+            'flyway.datasources.default.clean-schema'      : true
+        )
 
         when: 'running the migrations'
         applicationContext.getBean(DataSource)

--- a/flyway/src/test/groovy/io/micronaut/flyway/FlywayCleanSpec.groovy
+++ b/flyway/src/test/groovy/io/micronaut/flyway/FlywayCleanSpec.groovy
@@ -50,7 +50,9 @@ class FlywayCleanSpec extends AbstractFlywaySpec {
             'jpa.default.properties.hibernate.show_sql'    : true,
 
             'flyway.datasources.default.locations'         : 'classpath:moremigrations',
-            'flyway.datasources.default.clean-schema'      : true)
+            'flyway.datasources.default.clean-disabled'    : false,
+            'flyway.datasources.default.clean-schema'      : true
+        )
 
         and: 'running the migrations'
         applicationContext.getBean(DataSource)

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,11 +1,14 @@
 [versions]
 micronaut-docs = "2.0.0"
-micronaut = "4.0.0-RC1"
-micronaut-test = "4.0.0-M5"
-micronaut-sql = "5.0.0-M11"
+
+micronaut = "4.0.0-RC4"
+micronaut-test = "4.0.0-M8"
+micronaut-serde = "2.0.0-M12"
+micronaut-sql = "5.0.0-M12"
+
 micronaut-gradle-plugin = "4.0.0-M4"
 
-managed-flyway = "9.19.4"
+managed-flyway = "9.20.0"
 
 gorm-hibernate = "7.3.1"
 graal-svm = "23.0.0"
@@ -25,6 +28,7 @@ managed-flyway-oracle = { module = "org.flywaydb:flyway-database-oracle", versio
 grails-datastore-gorm-hibernate5 = { module = "org.grails:grails-datastore-gorm-hibernate5", version.ref = "gorm-hibernate" }
 graal-svm = { module = "org.graalvm.nativeimage:svm", version.ref = "graal-svm" }
 
+micronaut-serde = { module = "io.micronaut.serde:micronaut-serde-bom", version.ref = "micronaut-serde" }
 micronaut-sql = { module = "io.micronaut.sql:micronaut-sql-bom", version.ref = "micronaut-sql" }
 
 gradle-micronaut = { module = "io.micronaut.gradle:micronaut-gradle-plugin", version.ref = "micronaut-gradle-plugin" }

--- a/settings.gradle
+++ b/settings.gradle
@@ -15,9 +15,13 @@ include 'flyway'
 include 'flyway-bom'
 include 'test-suite-java'
 
+enableFeaturePreview('TYPESAFE_PROJECT_ACCESSORS')
+
 micronautBuild {
     useStandardizedProjectNames = true
+
     importMicronautCatalog()
+    importMicronautCatalog("micronaut-serde")
     importMicronautCatalog("micronaut-sql")
 }
 


### PR DESCRIPTION
Updated Flyway to latest version.
Switched to using Serde instead of Jackson.
Updated to latest RCs and Milestones of micronaut modules. Use Typesafe project accessors.