### PR TITLE
Enhance and clarify configuration `properties` map

### DIFF
--- a/flyway/src/main/java/io/micronaut/flyway/FlywayConfigurationProperties.java
+++ b/flyway/src/main/java/io/micronaut/flyway/FlywayConfigurationProperties.java
@@ -20,6 +20,7 @@ import io.micronaut.context.annotation.Context;
 import io.micronaut.context.annotation.EachProperty;
 import io.micronaut.context.annotation.Parameter;
 import io.micronaut.core.convert.format.MapFormat;
+import io.micronaut.core.naming.conventions.StringConvention;
 import io.micronaut.core.util.StringUtils;
 import io.micronaut.core.util.Toggleable;
 import org.flywaydb.core.api.configuration.FluentConfiguration;
@@ -193,20 +194,19 @@ public class FlywayConfigurationProperties implements Toggleable {
     }
 
     /**
-     * @see <a href="https://documentation.red-gate.com/fd/parameters-184127474.html">Flyway parameters</a>.
+     * @see <a href="https://documentation.red-gate.com/fd/flyway-cli-and-api/configuration/parameters">Flyway parameters</a>.
      * Sets the extra flyway parameters to be passed to {@link FluentConfiguration#configuration(Map)}.
-     * WARNING: This may override any existing configurations
+     * WARNING: This will override any existing configuration properties with the same names.
      *
      * @param properties The properties to be set
      */
-    public void setProperties(@MapFormat(transformation = MapFormat.MapTransformation.FLAT) Map<String, String> properties) {
+    public void setProperties(@MapFormat(transformation = MapFormat.MapTransformation.FLAT, keyFormat = StringConvention.CAMEL_CASE) Map<String, String> properties) {
         this.properties = properties;
     }
 
     /**
-     * @see <a href="https://documentation.red-gate.com/fd/parameters-184127474.html">Flyway parameters</a>.
+     * @see <a href="https://documentation.red-gate.com/fd/flyway-cli-and-api/configuration/parameters">Flyway parameters</a>.
      * Gets the extra flyway parameters to be passed to {@link FluentConfiguration#configuration(Map)}.
-     * WARNING: This may override any existing configurations
      *
      * @return The extra custom properties
      */

--- a/src/main/docs/guide/configuration/additionalConfig.adoc
+++ b/src/main/docs/guide/configuration/additionalConfig.adoc
@@ -7,11 +7,13 @@ NOTE: By default Micronaut will configure Flyway to use the datasources defined 
 you want to use a different datasource you need to define the properties `+flyway.datasources.*.url+`, `+flyway.datasources.*.user+`
 and `+flyway.datasources.*.password+`.
 
-=== Flyway Parameters
+=== Flyway Configuration Parameters
 
-You can setup https://documentation.red-gate.com/fd/parameters-184127474.html[flyway parameters]. For example, you can setup https://documentation.red-gate.com/fd/postgresql-transactional-lock-184127530.html[PostgreSQL Transactional Lock]:
+You can set https://documentation.red-gate.com/fd/flyway-cli-and-api/configuration/parameters[flyway configuration parameters]. For example, you can setup https://documentation.red-gate.com/fd/flyway-cli-and-api/configuration/parameters/flyway/postgresql-transactional-lock[PostgreSQL Transactional Lock]:
 
 [configuration]
 ----
 include::{flywaytests}/groovy/io/micronaut/flyway/postgresql/TransactionLockSpec.groovy[tag=yaml,indent=0]
 ----
+
+Note that setting configuration this way will override any matching properties set via the known configuration keys in the tables above.


### PR DESCRIPTION
The `properties` setter in `FlywayConfigurationProperties` is enhanced to convert property keys to camel case as 
required by Flyway's `FluentConfiguration` builder class.

Documentation is clarified and links to the Flyway documentation are updated to use permalinks.
