### PR TITLE
Allow disabling ImageSingletons lookups

### DIFF
--- a/flyway/src/main/java/io/micronaut/flyway/StaticResourceProvider.java
+++ b/flyway/src/main/java/io/micronaut/flyway/StaticResourceProvider.java
@@ -53,6 +53,7 @@ import org.graalvm.nativeimage.ImageSingletons;
  */
 @Internal
 final class StaticResourceProvider implements ResourceProvider {
+    private static final String GRAALVM_IMAGESINGLETONS_ENABLED = "micronaut.graalvm.imagesingletons.enabled";
     private static final String FLYWAY_LOCATIONS = "flyway.locations";
     private static final String DEFAULT_FLYWAY_LOCATIONS = "classpath:db/migration";
     private static final String CLASSPATH_APPLICATION_MIGRATIONS_PROTOCOL = "classpath";
@@ -112,6 +113,9 @@ final class StaticResourceProvider implements ResourceProvider {
 
     @SuppressWarnings("java:S1181")
     private static boolean hasImageSingletons() {
+        if ("false".equalsIgnoreCase(System.getProperty(GRAALVM_IMAGESINGLETONS_ENABLED))) {
+            return false;
+        }
         try {
             //noinspection ConstantValue
             return ImageSingletons.class != null;

--- a/flyway/src/main/java/io/micronaut/flyway/StaticResourceProvider.java
+++ b/flyway/src/main/java/io/micronaut/flyway/StaticResourceProvider.java
@@ -15,6 +15,8 @@
  */
 package io.micronaut.flyway;
 
+import static io.micronaut.core.util.StringUtils.FALSE;
+
 import java.io.ByteArrayInputStream;
 import java.io.File;
 import java.io.IOException;
@@ -113,7 +115,7 @@ final class StaticResourceProvider implements ResourceProvider {
 
     @SuppressWarnings("java:S1181")
     private static boolean hasImageSingletons() {
-        if ("false".equalsIgnoreCase(System.getProperty(GRAALVM_IMAGESINGLETONS_ENABLED))) {
+        if (FALSE.equalsIgnoreCase(System.getProperty(GRAALVM_IMAGESINGLETONS_ENABLED))) {
             return false;
         }
         try {

--- a/flyway/src/test/groovy/io/micronaut/flyway/StaticResourceProviderSpec.groovy
+++ b/flyway/src/test/groovy/io/micronaut/flyway/StaticResourceProviderSpec.groovy
@@ -4,6 +4,20 @@ package io.micronaut.flyway
 import spock.lang.Specification
 
 class StaticResourceProviderSpec extends Specification {
+    private String previousImageSingletonsEnabled
+
+    def setup() {
+        previousImageSingletonsEnabled = System.getProperty('micronaut.graalvm.imagesingletons.enabled')
+    }
+
+    void cleanup() {
+        if (previousImageSingletonsEnabled == null) {
+            System.clearProperty('micronaut.graalvm.imagesingletons.enabled')
+        } else {
+            System.setProperty('micronaut.graalvm.imagesingletons.enabled', previousImageSingletonsEnabled)
+        }
+    }
+
     void "test static resource provider"() {
         given:
         def resourceProvider = StaticResourceProvider.create(Thread.currentThread().getContextClassLoader())
@@ -16,5 +30,13 @@ class StaticResourceProviderSpec extends Specification {
         resources.find { it.filename == 'V1__create-books-schema.sql' }
         resources.find { it.filename == 'V1__create-books-schema.sql' }
             .read().text.contains("create table books")
+    }
+
+    void "image singletons lookup can be disabled"() {
+        given:
+        System.setProperty('micronaut.graalvm.imagesingletons.enabled', 'false')
+
+        expect:
+        StaticResourceProvider.get() == null
     }
 }


### PR DESCRIPTION
Add a system property to disable optional ImageSingletons detection before calling ImageSingletons APIs.

This supports runtimes such as Crema where ImageSingletons.contains is not reachable. The default behavior is unchanged; setting `micronaut.graalvm.imagesingletons.enabled=false` skips the lookup.

Tests: `./gradlew :micronaut-flyway:test --tests io.micronaut.flyway.StaticResourceProviderSpec`